### PR TITLE
Fix SECRET frame strata error in tooltip progress bar

### DIFF
--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -102,7 +102,9 @@ local function TSV_ShowProgressBar(tooltip, min, max, value, barLabel, r, g, b)
     end
 
     tsvBarFrame:SetParent(tooltip)
-    tsvBarFrame:SetFrameStrata(tooltip:GetFrameStrata())
+    local strata = tooltip:GetFrameStrata()
+    if strata == "SECRET" then strata = "TOOLTIP" end
+    tsvBarFrame:SetFrameStrata(strata)
     tsvBarFrame:SetFrameLevel(tooltip:GetFrameLevel() + 1)
     tsvBarFrame.Bar:SetMinMaxValues(min, max)
     tsvBarFrame.Bar:SetValue(value)

--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -102,9 +102,7 @@ local function TSV_ShowProgressBar(tooltip, min, max, value, barLabel, r, g, b)
     end
 
     tsvBarFrame:SetParent(tooltip)
-    local strata = tooltip:GetFrameStrata()
-    if strata == "SECRET" then strata = "TOOLTIP" end
-    tsvBarFrame:SetFrameStrata(strata)
+    tsvBarFrame:SetFrameStrata("TOOLTIP")
     tsvBarFrame:SetFrameLevel(tooltip:GetFrameLevel() + 1)
     tsvBarFrame.Bar:SetMinMaxValues(min, max)
     tsvBarFrame.Bar:SetValue(value)


### PR DESCRIPTION
`GetFrameStrata()` on GameTooltip can return `"SECRET"`, which isn't a valid arg for `SetFrameStrata()` and throws an error. This falls back to `"TOOLTIP"` strata instead.

Fixes #30