### PR TITLE
Use issecretvalue checks to prevent secret-value taint errors

### DIFF
--- a/Tooltips.lua
+++ b/Tooltips.lua
@@ -176,18 +176,20 @@ function addon.tsv:OnTooltip(ev, tooltip, ...)
                                 for _, pattern in ipairs(patternList) do
                                     local amount = string.match(text, pattern)
                                     if (amount) then
-                                        local s, e = string.find(text, pattern)
                                         local trueAmount = self:GetTrueStatRatingAdded(statId, amount)
-                                        local r, g, b =
-                                            addon.tsv.db.global.fontColor.r,
-                                            addon.tsv.db.global.fontColor.g,
-                                            addon.tsv.db.global.fontColor.b
-                                        local hexStr = RGBPercToHex(r, g, b)
+                                        if trueAmount ~= nil then
+                                            local s, e = string.find(text, pattern)
+                                            local r, g, b =
+                                                addon.tsv.db.global.fontColor.r,
+                                                addon.tsv.db.global.fontColor.g,
+                                                addon.tsv.db.global.fontColor.b
+                                            local hexStr = RGBPercToHex(r, g, b)
 
-                                        local trueText =
-                                            text:sub(1, e) ..
-                                            " |cff" .. hexStr .. "(" .. tostring(trueAmount) .. ")|r" .. text:sub(e + 1)
-                                        _G[textleft]:SetText(trueText)
+                                            local trueText =
+                                                text:sub(1, e) ..
+                                                " |cff" .. hexStr .. "(" .. tostring(trueAmount) .. ")|r" .. text:sub(e + 1)
+                                            _G[textleft]:SetText(trueText)
+                                        end
                                         break
                                     end
                                 end
@@ -203,7 +205,15 @@ function addon.tsv:OnTooltip(ev, tooltip, ...)
 end
 
 function addon.tsv:AddTrueStatValuesTooltip(tooltip, statId)
-    local statInfo = addon.TrueStatInfo[statId]
+    local statInfo = addon.TrueStatInfo and addon.TrueStatInfo[statId]
+    if not statInfo
+        or statInfo.bracketPenalty   == nil
+        or statInfo.bracketRating    == nil
+        or statInfo.bracketMaxRating == nil
+        or statInfo.baseRating       == nil
+        or statInfo.trueRating       == nil then
+        return
+    end
     local pctLabel = (statInfo.bracketPenalty > 0) and ("-" .. tostring(statInfo.bracketPenalty * 100) .. "%") or ("0%")
     local barLabel =
         tostring(statInfo.bracketRating) ..

--- a/TrueStatValues.lua
+++ b/TrueStatValues.lua
@@ -239,8 +239,14 @@ function addon.tsv:GetStatDiminishBracket(statId,amount)
 
     local rating = addon[stat.rating];
     local conversionFactor = addon[stat.conversionFactor];
-    local amount = amount or 0;
+    amount = amount or 0;
     local bracket = addon.tsv[stat.bracket];
+
+    if rating == nil or conversionFactor == nil or conversionFactor == 0
+        or issecretvalue(rating) or issecretvalue(amount)
+        or type(rating) ~= "number" or type(amount) ~= "number" then
+        return;
+    end
 
     local percent = (rating+amount) / conversionFactor;
     local bracket_rating = 0;
@@ -268,19 +274,37 @@ function addon.tsv:GetStatDiminishBracket(statId,amount)
 end
 
 
-function addon.tsv:RecalculateTrueStatRatings() 
-    if not InCombatLockdown() then
-        addon.BaseCritRating = GetCombatRating(CR_CRIT_SPELL);
-        addon.BaseHasteRating = GetCombatRating(CR_HASTE_SPELL);
-        addon.BaseMasteryRating = GetCombatRating(CR_MASTERY);
-        addon.BaseVersatilityRating = GetCombatRating(CR_VERSATILITY_DAMAGE_DONE);
-        addon.BaseLeechRating = GetCombatRating(CR_LIFESTEAL);
-        addon.BaseAvoidanceRating = GetCombatRating(CR_AVOIDANCE);
-        addon.BaseSpeedRating = GetCombatRating(CR_SPEED);
-        
-        addon.TrueStatInfo = addon.TrueStatInfo or {};
-        for statId,stat in pairs(statIdMap) do 
-            local true_rating, bracket_penalty, bracket_next_penalty, bracket_rating, bracket_max_rating = self:GetStatDiminishBracket(statId);
+function addon.tsv:RecalculateTrueStatRatings()
+    if InCombatLockdown() then return end
+
+    local crit    = GetCombatRating(CR_CRIT_SPELL);
+    local haste   = GetCombatRating(CR_HASTE_SPELL);
+    local mastery = GetCombatRating(CR_MASTERY);
+    local vers    = GetCombatRating(CR_VERSATILITY_DAMAGE_DONE);
+    local leech   = GetCombatRating(CR_LIFESTEAL);
+    local avoid   = GetCombatRating(CR_AVOIDANCE);
+    local speed   = GetCombatRating(CR_SPEED);
+
+    -- GetCombatRating may return secret values even when InCombatLockdown is false;
+    -- bail rather than poison addon state. Next COMBAT_RATING_UPDATE will retry.
+    if issecretvalue(crit) or issecretvalue(haste) or issecretvalue(mastery)
+        or issecretvalue(vers) or issecretvalue(leech)
+        or issecretvalue(avoid) or issecretvalue(speed) then
+        return;
+    end
+
+    addon.BaseCritRating        = crit;
+    addon.BaseHasteRating       = haste;
+    addon.BaseMasteryRating     = mastery;
+    addon.BaseVersatilityRating = vers;
+    addon.BaseLeechRating       = leech;
+    addon.BaseAvoidanceRating   = avoid;
+    addon.BaseSpeedRating       = speed;
+
+    addon.TrueStatInfo = addon.TrueStatInfo or {};
+    for statId,stat in pairs(statIdMap) do
+        local true_rating, bracket_penalty, bracket_next_penalty, bracket_rating, bracket_max_rating = self:GetStatDiminishBracket(statId);
+        if true_rating ~= nil then
             addon.TrueStatInfo[statId] = {
                 bracketPenalty = bracket_penalty,
                 bracketNextPenalty = bracket_next_penalty,
@@ -295,11 +319,17 @@ function addon.tsv:RecalculateTrueStatRatings()
 end
 
 function addon.tsv:GetTrueStatRatingAdded(statId,amountStr)
-    local amountStr = amountStr:gsub(",",""); --numbers are big enough to have commas now
+    if not amountStr then return nil; end
+    amountStr = amountStr:gsub(",",""); --numbers are big enough to have commas now
     local amount = tonumber(amountStr);
-    local currentTrueRating = addon.TrueStatInfo[statId].trueRating;
+    if not amount then return nil; end
+
+    local info = addon.TrueStatInfo and addon.TrueStatInfo[statId];
+    if not info or info.trueRating == nil then return nil; end
+
     local addedTrueRating = self:GetStatDiminishBracket(statId,amount);
-    local diff = addedTrueRating - currentTrueRating;
-    diff = math.floor(0.005+100*diff)/100;
-    return diff;
+    if addedTrueRating == nil then return nil; end
+
+    local diff = addedTrueRating - info.trueRating;
+    return math.floor(0.005+100*diff)/100;
 end

--- a/TrueStatValues.toc
+++ b/TrueStatValues.toc
@@ -1,7 +1,7 @@
 ## Interface: 120001, 120005
 ## Title: True Stat Values
 ## Author: .bastas (discord), tirain (discord), hinalover (discord)
-## Version: 1.5.2
+## Version: 1.5.3
 ## Notes: Show Secondary-Stat Diminishing Returns in Tooltips.
 ## Notes-zhCN: 在属性栏显示数值详细递减信息。
 ## DefaultState: Enabled


### PR DESCRIPTION
## Summary
- `RecalculateTrueStatRatings` now reads each `GetCombatRating()` into a local and aborts the recalc if any return is a secret value, instead of relying solely on `InCombatLockdown()`. This prevents `addon.BaseXxxRating` from ever being assigned a secret value.
- `GetStatDiminishBracket` (the line-245 crash site) and `GetTrueStatRatingAdded` now defensively bail when their inputs are nil, secret, or otherwise unusable.
- Tooltip code in `Tooltips.lua` skips the annotation when `GetTrueStatRatingAdded` returns nil and `AddTrueStatValuesTooltip` guards its `statInfo` reads, so a not-yet-populated cache no longer throws.
- Bumped version to 1.5.3.

Fixes the recurring `attempt to perform arithmetic on local 'rating' (a secret number value...)` error reported through in-game error handlers.