### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: BigWigsMods/packager@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.release/

--- a/TrueStatValues.toc
+++ b/TrueStatValues.toc
@@ -1,12 +1,13 @@
 ## Interface: 120001, 120005
 ## Title: True Stat Values
 ## Author: .bastas (discord), tirain (discord), hinalover (discord)
-## Version: 1.5.3
+## Version: @project-version@
 ## Notes: Show Secondary-Stat Diminishing Returns in Tooltips.
 ## Notes-zhCN: 在属性栏显示数值详细递减信息。
 ## DefaultState: Enabled
 ## SavedVariables: TSV_DB 
 ## IconTexture: Interface\Addons\TrueStatvalues\TrueStatvalues
+## X-Curse-Project-ID: 437378
 
 embeds.xml
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — on every git tag push, [BigWigsMods/packager](https://github.com/BigWigsMods/packager) builds a zip, creates a GitHub Release, and uploads to CurseForge (project ID `437378`).
- Replaces the hardcoded `## Version: 1.5.3` in `TrueStatValues.toc` with `## Version: @project-version@`. The packager substitutes the tag name at build time, so version bumps are now just `git tag <version> && git push origin <version>`.
- Adds `## X-Curse-Project-ID: 437378` to the `.toc` so the packager knows where to publish on CurseForge.
- Adds `.gitignore` for `.release/` (the packager's build output dir).

The `CF_API_KEY` secret has already been added to the repo. `GITHUB_TOKEN` is provided automatically by Actions.
