### PR TITLE
Grant contents:write to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}
       GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow uploads to CurseForge successfully but fails at the final step when creating the GitHub release:

```
Creating GitHub release: .../releases/tag/1.5.7
Error! (403) "Resource not accessible by integration"
```

The repo default workflow token permission is `read` (`default_workflow_permissions: "read"`) and `release.yml` never declared a `permissions:` block, so `GITHUB_TOKEN` cannot create releases. The CurseForge upload is unaffected since it authenticates with `CF_API_KEY`.

Adding `permissions: contents: write` to the job lets the packager create the GitHub release alongside the CurseForge upload. Takes effect on the next tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
